### PR TITLE
Support to .srt and external subtitles

### DIFF
--- a/extract-dialogue.sh
+++ b/extract-dialogue.sh
@@ -38,7 +38,7 @@ while [ -n "$1" ]; do
     case "$1" in
         "-i") shift; file="$1"   ;;
         "-a") shift; audio="$1"  ;;
-        "-s"|"-S") shift; subs="$1"   ;;
+        "-s") shift; subs="$1"   ;;
         "-o") shift; output="$1" ;;
         "-h") usage              ;;
         *) error "There was an error parsing arguments. Make sure to use the -i option." ;;

--- a/extract-dialogue.sh
+++ b/extract-dialogue.sh
@@ -26,6 +26,9 @@ error() {
 [ -z "$1" ] && usage
 
 dialogues () {
+    # Parses the subtitles file to the format BEGIN,END
+    # BEGIN and END are in the format HH:MM:SS.sss
+    # H: hour, M: minute, S: second, s: milisecond
     extension=$(echo "$1" | sed 's/.*\.\(.*\)/\1/')
     if [ "$extension" = 'ass' ]; then
         grep "^Dialogue:.*" "$1" | cut -f "2,3" -d "," | uniq | tr '\n' ' '
@@ -48,6 +51,7 @@ done
 
 audio_id=$(ffprobe "$file" 2>&1 | grep "Stream .*Audio" | sed -n "${audio:-1}p" | grep -o '[0-9]:[0-9]')
 
+# Look for an existing subtitles file, and, if absent, generate one from the video file
 if [ ! -f "$subs" ]; then
     subs_id=$(ffprobe "$file" 2>&1 | grep "Stream .*Subtitle" | sed -n "${subs:-1}p" | grep -o '[0-9]:[0-9]')
     [ -z "$subs_id" ] && error "No text-based subtitles found."

--- a/extract-dialogue.sh
+++ b/extract-dialogue.sh
@@ -68,13 +68,15 @@ timestamps=$(dialogues "$subs_file")
 [ -z "$timestamps" ] && error "Subtitles file was found, but parsing failed."
 
 num=1
+# Use the same extension as the output file for the intermediate files
+ext=$(echo "${output:=output.mp3}" | sed 's/.*\.\(.*\)/\1/')
 for timestamp in $timestamps; do
     begin=$(echo "$timestamp" | cut -f1 -d,)
     end=$(  echo "$timestamp" | cut -f2 -d,)
-    ffmpeg -y -loglevel fatal -ss "$begin" -to "$end" -i "$file" -map $audio_id "$temp/$num.mp3"
-    if ffprobe -i "$temp/$num.mp3" 2> /dev/null; then
-        echo "$num.mp3 : $begin -> $end"
-        echo "file '$temp/$num.mp3'" >> "$temp/list.txt"
+    ffmpeg -y -loglevel fatal -ss "$begin" -to "$end" -i "$file" -map $audio_id "$temp/$num.$ext"
+    if ffprobe -i "$temp/$num.$ext" 2> /dev/null; then
+        echo "$num.$ext : $begin -> $end"
+        echo "file '$temp/$num.$ext'" >> "$temp/list.txt"
         num="$(( $num + 1 ))"
     fi
 done


### PR DESCRIPTION
Now the -s option allows for a subtitle file and, in case one isn't found, the subs.ass is generated from the video file.
Also, .srt files are now supported and the parsing is now made within the _dialogues_function.